### PR TITLE
adbportforwarding.jar to be configured to make visible USB devices inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN dpkg --add-architecture i386 && \
 #===============================================================
 RUN wget --no-verbose https://bitbucket.org/chabernac/adbportforward/downloads/adbportforward.jar -O /home/adbportforward.jar
 
+
 #================================================================
 # Creates Nexus 5 Android-24 Emulator by default
 #================================================================
@@ -128,6 +129,11 @@ RUN appium-doctor --android
 ENV UDEV_REMOTE_FILE https://raw.githubusercontent.com/M0Rf30/android-udev-rules/master/ubuntu/51-android.rules
 RUN mkdir /etc/udev/rules.d \
   && wget --no-verbose $UDEV_REMOTE_FILE -O /etc/udev/rules.d/51-android.rules
+
+#===============================================================
+# Invoke adbportforwarding client -- For OSX
+#===============================================================
+CMD java -jar adbportforward.jar client adblocation=$ANDROID_HOME/platform-tools/ remotehost=127.0.0.1 port=6037 &
 
 #=======================================
 # Expose default port of appium

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,11 @@ RUN dpkg --add-architecture i386 && \
     apt-get autoremove --purge -y && \
     apt-get clean
 
+#===============================================================
+# Download adbportforward.jar to /home -- For OSX
+#===============================================================
+RUN wget --no-verbose https://bitbucket.org/chabernac/adbportforward/downloads/adbportforward.jar -O /home/adbportforward.jar
+
 #================================================================
 # Creates Nexus 5 Android-24 Emulator by default
 #================================================================

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ docker run -it appium/appium-docker-android bash
 ```Dockerfile
 FROM appium/appium-docker-android:latest
 ```
+
+### Below are commands added to download adbportforwarding for OSX
+```Dockerfile
+RUN wget --no-verbose https://bitbucket.org/chabernac/adbportforward/downloads/adbportforward.jar -O /home/adbportforward.jar
+```
+
+
+### Invoke adbportforwarding client -- For OSX
+```Dockerfile
+CMD java -jar /home/adbportforward.jar client adblocation=$ANDROID_HOME/platform-tools/ remotehost=127.0.0.1 port=6037 &
+```


### PR DESCRIPTION
In OSX environment, USB devices are not visible by adb server. Hence adbportforwarding.jar needs to be downloaded as a part of container. 

