### PR TITLE
Add installation of libgconf-2-4 for chromedriver to work

### DIFF
--- a/Appium/Dockerfile
+++ b/Appium/Dockerfile
@@ -28,6 +28,8 @@ WORKDIR /root
 #   Web content engine (Fix issue in Android)
 # bats
 #   Testing framework for Bash
+# libgconf-2-4
+#   Required package for chrome and chromedriver to run on Linux
 #==================
 RUN apt-get -qqy update && \
     apt-get -qqy --no-install-recommends install \
@@ -39,6 +41,7 @@ RUN apt-get -qqy update && \
     wget \
     libqt5webkit5 \
     bats \
+    libgconf-2-4 \
   && rm -rf /var/lib/apt/lists/*
 
 #===============


### PR DESCRIPTION
This library installation fixes chromedriver crash when running tests with chrome browser using chromedriver:
```
[Chromedriver] [STDERR] /usr/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_64: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
[Chromedriver] Chromedriver exited unexpectedly with code 127, signal null
```
The same fix was applied [here](https://github.com/andrcuns/docker-android/commit/c3ad9b3d485d1042827fd62b05a88f5bbc6f2fbf) as well.