### PR TITLE
Removed invalid link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Images Included:
 
-- appium/appium - Docker Image to run appium tests on real android devices. See doc [here](https://github.com/appium/appium-docker-android/blob/master/Appium/README.md)
+- appium/appium - Docker Image to run appium tests on real android devices.
 - To execute in android emulator's please visit [docker-android](https://github.com/butomo1989/docker-appium.git)
 
 ## Setting up Android real device test on Docker macOSX


### PR DESCRIPTION
Link to second readme is invalid because it is already deleted in [previous commit](https://github.com/appium/appium-docker-android/commit/65b8fcd60bc8e893590c8d2ca4479725956e68bf).