### PR TITLE
(Killer feature) Fixed issue, that prevents (re)start container

### DIFF
--- a/Appium/entry_point.sh
+++ b/Appium/entry_point.sh
@@ -8,4 +8,6 @@ if [ ! -z "$CONNECT_TO_GRID" ]; then
   CMD+=" --nodeconfig $NODE_CONFIG_JSON"
 fi
 
+pkill -x xvfb-run
+
 $CMD


### PR DESCRIPTION
After container was shutted down, it could not be started again, because appium instanse already running and fails with error: `Unable to run xvfb-run`