### PR TITLE
Added Android Platform into Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - docker -v
 
 script:
-  - docker build -t "appium/appium:latest" --build-arg SDK_VERSION=$SDK_VERSION --build-arg ANDROID_BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION --build-arg APPIUM_VERSION=$APPIUM_VERSION -f Appium/Dockerfile .
+  - docker build -t "appium/appium:latest" --build-arg SDK_VERSION=$SDK_VERSION --build-arg ANDROID_BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION --build-arg APPIUM_VERSION=$APPIUM_VERSION  -f Appium/Dockerfile .
   - docker run --rm -v $PWD/Appium/tests:/root/tests "appium/appium:latest" bash tests/run-bats.sh
   - docker images
 

--- a/Appium/Dockerfile
+++ b/Appium/Dockerfile
@@ -18,6 +18,8 @@ WORKDIR /root
 #   SSL client
 # tzdata
 #   Timezone
+# zip
+#   Make a zip file
 # unzip
 #   Unzip zip file
 # curl
@@ -36,6 +38,7 @@ RUN apt-get -qqy update && \
     openjdk-8-jdk \
     ca-certificates \
     tzdata \
+    zip \
     unzip \
     curl \
     wget \
@@ -55,6 +58,8 @@ ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre" \
 #=====================
 ARG SDK_VERSION=sdk-tools-linux-3859397
 ARG ANDROID_BUILD_TOOLS_VERSION=26.0.0
+ARG ANDROID_PLATFORM_VERSION="android-25"
+
 ENV SDK_VERSION=$SDK_VERSION \
     ANDROID_BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION \
     ANDROID_HOME=/root
@@ -63,14 +68,16 @@ RUN wget -O tools.zip https://dl.google.com/android/repository/${SDK_VERSION}.zi
     unzip tools.zip && rm tools.zip && \
     chmod a+x -R $ANDROID_HOME && \
     chown -R root:root $ANDROID_HOME
+
 ENV PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin
 
 # https://askubuntu.com/questions/885658/android-sdk-repositories-cfg-could-not-be-loaded
-RUN mkdir -p ~/.android
-RUN touch ~/.android/repositories.cfg
+RUN mkdir -p ~/.android && \
+    touch ~/.android/repositories.cfg && \
+    echo y | sdkmanager "platform-tools" && \
+    echo y | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION" && \
+    echo y | sdkmanager "platforms;$ANDROID_PLATFORM_VERSION"
 
-RUN echo y | sdkmanager "platform-tools"
-RUN echo y | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION"
 ENV PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools
 
 #====================================
@@ -109,8 +116,8 @@ COPY \
   Appium/entry_point.sh \
   Appium/generate_config.sh \
     /root/
-RUN chmod +x /root/entry_point.sh
-RUN chmod +x /root/generate_config.sh
+RUN chmod +x /root/entry_point.sh && \
+    chmod +x /root/generate_config.sh
 
 #========================================
 # Run xvfb and appium server

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 	}
 	```
 
-### Connect to Android devices by Air
+## Connect to Android devices by Air
 
 Appium-Docker-Android can be connected with Android devices by Air.
 


### PR DESCRIPTION
Now docker image contains android SDK platform to be able to run automation tests.
Otherwise it fails with error `Required platform doesn't exist (API level >= 17)`

By providing following environment variable to travis, it will prepare the image with Android platform 25, which is the hightest, that Appium `1.6.6-beta` supports:
`ANDROID_PLATFORM_VERSION='android-25'`

I found these platform versions in Appium sources

`...node_modules/appium/node_modules/appium-adb/lib/helpers.js`

```
const androidPlatforms = ['android-4.2', 'android-17', 'android-4.3', 'android-18',
                          'android-4.4', 'android-19', 'android-L', 'android-20',
                          'android-5.0', 'android-21', 'android-22', 'android-MNC',
                          'android-23', 'android-6.0', 'android-N', 'android-24',
                          'android-25'];
```