### PR TITLE
Added node timeout variable

### DIFF
--- a/Appium/generate_config.sh
+++ b/Appium/generate_config.sh
@@ -26,6 +26,10 @@ if [ -z "$BROWSER_NAME" ]; then
   BROWSER_NAME="android"
 fi
 
+if [ -z "$NODE_TIMEOUT" ]; then
+  NODE_TIMEOUT=300
+fi
+
 if [ ! -z "$REMOTE_ADB" ]; then
     if [ ! -z "$ANDROID_DEVICES" ]; then
         IFS=',' read -r -a array <<< "$ANDROID_DEVICES"
@@ -73,7 +77,7 @@ nodeconfig=$(cat <<_EOF
   "capabilities": [$(create_capabilities)],
   "configuration": {
     "cleanUpCycle": 2000,
-    "timeout": 30000,
+    "timeout": $NODE_TIMEOUT,
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
     "url": "http://$APPIUM_HOST:$APPIUM_PORT/wd/hub",
     "host": "$APPIUM_HOST",

--- a/Appium/tests/grid.bats
+++ b/Appium/tests/grid.bats
@@ -21,7 +21,7 @@ default_node_config=\
   }],
   "configuration": {
     "cleanUpCycle": 2000,
-    "timeout": 30000,
+    "timeout": 300,
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
     "url": "http://127.0.0.1:4723/wd/hub",
     "host": "127.0.0.1",


### PR DESCRIPTION
Change default timeout to 300 sec
User can now set NODE_TIMEOUT to set custom timeout when grid will release a node

Current timeout is set to 30000 sec, this is too much and grid can't release node for a long time. 

Grid documentation: 

> -timeout 30 (300 is default) The timeout in seconds before the hub automatically releases a node that hasn't received any requests for more than the specified number of seconds. After this time, the node will be released for another test in the queue. This helps to clear client crashes without manual intervention. To remove the timeout completely, specify -timeout 0 and the hub will never release the node.