### PR TITLE
Using container ip address

### DIFF
--- a/Appium/generate_config.sh
+++ b/Appium/generate_config.sh
@@ -7,7 +7,7 @@ if [ -z "$PLATFORM_NAME" ]; then
 fi
 
 if [ -z "$APPIUM_HOST" ]; then
-  APPIUM_HOST="127.0.0.1"
+  APPIUM_HOST=$(hostname -i)
 fi
 
 if [ -z "$APPIUM_PORT" ]; then

--- a/Appium/tests/grid.bats
+++ b/Appium/tests/grid.bats
@@ -46,7 +46,7 @@ adb_devices_output='73QDU16916010699 device 4b13354b80b36200 device'
     "-s 4b13354b80b36200 shell getprop ro.build.version.release : echo 5.1.1" \
     "-s 4b13354b80b36200 shell getprop ro.serialno : echo 4b13354b80b36200"
 
-  run /root/generate_config.sh $node_config_json
+  APPIUM_HOST=127.0.0.1 run /root/generate_config.sh $node_config_json
   [ "$(cat $node_config_json)" == "$default_node_config" ]
 
   unstub adb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     privileged: true
     volumes:
       - /dev/bus/usb:/dev/bus/usb
+      - ~/.android:/root/.android
     environment:
       - CONNECT_TO_GRID=True
       - SELENIUM_HOST=selenium_hub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ version: '2'
 services:
   # Selenium hub
   selenium_hub:
-    image: selenium/hub:3.4.0
+    image: selenium/hub:3.7.1
     ports:
       - 4444:4444
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - 4444:4444
 
-  # Appium Docker Android
-  appium_devices:
+  # Appium Docker Android  
+  appium_android_device:
     image: appium/appium
     depends_on:
       - selenium_hub
@@ -23,3 +23,5 @@ services:
     environment:
       - CONNECT_TO_GRID=True
       - SELENIUM_HOST=selenium_hub
+      # Enable it for msite testing
+      #- BROWSER_NAME=chrome

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     image: appium/appium
     depends_on:
       - selenium_hub
-    network_mode: "service:selenium_hub"
     privileged: true
     volumes:
       - /dev/bus/usb:/dev/bus/usb


### PR DESCRIPTION
It uses container IP address so that container do not need to run in the same network where docker-selenium hub is running. 