### PR TITLE
Add steps to connect to host's adb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ version: '2'
 services:
   # Selenium hub
   selenium_hub:
-    image: selenium/hub:3.7.1
+    image: selenium/hub
     ports:
       - 4444:4444
 


### PR DESCRIPTION
I added some steps how to connect the container to host's adb. 
It would be useful because no docker-machine needed. Espacially for mac user that have Android Emulator run on their host adb as it will run slow in the container(ARM only).