### PR TITLE
ChromeDriver Autodownload

### DIFF
--- a/Appium/entry_point.sh
+++ b/Appium/entry_point.sh
@@ -37,6 +37,10 @@ if [ "$RELAXED_SECURITY" = true ]; then
     CMD+=" --relaxed-security"
 fi
 
+if [ "$CHROMEDRIVER_AUTODOWNLOAD" = true ]; then
+    CMD+=" chromedriver_autodownload"
+fi
+
 pkill -x xvfb-run
 rm -rf /tmp/.X99-lock
 


### PR DESCRIPTION
Adding the ChromeDriver AutoDownload option.

I'm adding this option because the server seems to not be able to use the Chrome 78 installed in most of my devices.