### PR TITLE
Upgrade node version to LTS (node 12)

### DIFF
--- a/Appium/Dockerfile
+++ b/Appium/Dockerfile
@@ -93,7 +93,7 @@ ENV PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools
 ARG APPIUM_VERSION=1.7.0-beta
 ENV APPIUM_VERSION=$APPIUM_VERSION
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash && \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash && \
     apt-get -qqy install nodejs && \
     npm install -g appium@${APPIUM_VERSION} --unsafe-perm=true --allow-root && \
     exit 0 && \


### PR DESCRIPTION
Node.js 12x is now the LTS
Node.js 10x is will soon be in Maintenance only phase.
https://nodejs.org/en/about/releases/