### PR TITLE
APPIUM_VERSION update

### DIFF
--- a/Appium/Dockerfile
+++ b/Appium/Dockerfile
@@ -92,7 +92,7 @@ ENV PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools
 # Install latest nodejs, npm, appium
 # Using this workaround to install Appium -> https://github.com/appium/appium/issues/10020 -> Please remove this workaround asap
 #====================================
-ARG APPIUM_VERSION=1.7.0-beta
+ARG APPIUM_VERSION=1.17.1
 ENV APPIUM_VERSION=$APPIUM_VERSION
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash && \


### PR DESCRIPTION
Project doesn't build because of outdated dependencies in current appium version.
APPIUM_VERSION update fixed that.