### PR TITLE
Support dynamic log file path

### DIFF
--- a/Appium/entry_point.sh
+++ b/Appium/entry_point.sh
@@ -2,7 +2,7 @@
 
 NODE_CONFIG_JSON="/root/nodeconfig.json"
 DEFAULT_CAPABILITIES_JSON="/root/defaultcapabilities.json"
-APPIUM_LOG="/var/log/appium.log"
+APPIUM_LOG="${APPIUM_LOG:-/var/log/appium.log}"
 CMD="xvfb-run appium --log $APPIUM_LOG"
 
 if [ ! -z "${SALT_MASTER}" ]; then


### PR DESCRIPTION
This allows the APPIUM_LOG variable to be overridden in the container environment variables. If its not set then it still defaults to `/var/log/appium.log` so not to break existing setups.