### PR TITLE
Remove old comment regarding appium install workaround

### DIFF
--- a/Appium/Dockerfile
+++ b/Appium/Dockerfile
@@ -107,7 +107,6 @@ ENV PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools
 
 #====================================
 # Install latest nodejs, npm, appium
-# Using this workaround to install Appium -> https://github.com/appium/appium/issues/10020 -> Please remove this workaround asap
 #====================================
 ENV NODE_VERSION=22
 ENV APPIUM_VERSION=2.18.0


### PR DESCRIPTION
In [82a72fc](https://github.com/appium/appium-docker-android/commit/82a72fc8dce5969229699218a3fdc032e14018b2), the workaround has ben removed and thus the comment is no longer needed. 